### PR TITLE
Stop recursing on 'sub components' and Supply admin searching

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,5 @@
 eclipse.preferences.version=1
 encoding//ecm/apps/eve/migrations/0006_auto__add_field_blueprinttype_product_is_purchased.py=utf-8
 encoding//ecm/plugins/accounting/tasks/wallets.py=utf-8
+encoding//ecm/plugins/industry/migrations/0005_auto__add_field_supply_type.py=utf-8
 encoding/<project>=UTF-8

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,4 @@
 eclipse.preferences.version=1
+encoding//ecm/apps/eve/migrations/0006_auto__add_field_blueprinttype_product_is_purchased.py=utf-8
+encoding//ecm/plugins/accounting/tasks/wallets.py=utf-8
 encoding/<project>=UTF-8

--- a/ecm/apps/eve/admin.py
+++ b/ecm/apps/eve/admin.py
@@ -24,8 +24,11 @@ from ecm.apps.eve.models import Type, BlueprintType, BlueprintReq, CelestialObje
                                 Category, Group, MarketGroup, ControlTowerResource, SkillReq
 
 
+class BlueprintTypeAdmin(admin.ModelAdmin):
+    search_fields = ['type__typeName']
+
 admin.site.register(Type)
-admin.site.register(BlueprintType)
+admin.site.register(BlueprintType, BlueprintTypeAdmin)
 admin.site.register(MarketGroup)
 admin.site.register(BlueprintReq)
 admin.site.register(CelestialObject)

--- a/ecm/apps/eve/migrations/0006_auto__add_field_blueprinttype_product_is_purchased.py
+++ b/ecm/apps/eve/migrations/0006_auto__add_field_blueprinttype_product_is_purchased.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'BlueprintType.product_is_purchased'
+        db.add_column(u'eve_blueprinttype', 'product_is_purchased',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'BlueprintType.product_is_purchased'
+        db.delete_column(u'eve_blueprinttype', 'product_is_purchased')
+
+
+    models = {
+        'eve.blueprintreq': {
+            'Meta': {'ordering': "['blueprint', 'activityID', 'required_type']", 'object_name': 'BlueprintReq'},
+            'activityID': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'blueprint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'requirements'", 'db_column': "'blueprintTypeID'", 'to': "orm['eve.BlueprintType']"}),
+            'id': ('django.db.models.fields.BigIntegerField', [], {'primary_key': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'required_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['eve.Type']", 'db_column': "'requiredTypeID'"})
+        },
+        'eve.blueprinttype': {
+            'Meta': {'ordering': "['blueprintTypeID']", 'object_name': 'BlueprintType'},
+            'blueprintTypeID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'inventionBaseChance': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'inventionTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'maxProductionLimit': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parent_blueprint': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children_blueprints'", 'null': 'True', 'db_column': "'parentBlueprintTypeID'", 'to': "orm['eve.BlueprintType']"}),
+            'product': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['eve.Type']", 'unique': 'True', 'null': 'True', 'db_column': "'productTypeID'", 'blank': 'True'}),
+            'product_is_purchased': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'productionTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchCopyTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchMaterialTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchProductivityTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'eve.category': {
+            'Meta': {'ordering': "['categoryID']", 'object_name': 'Category'},
+            'categoryID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'categoryName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'eve.celestialobject': {
+            'Meta': {'ordering': "['itemID']", 'object_name': 'CelestialObject'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['eve.Group']", 'null': 'True', 'db_column': "'groupID'", 'blank': 'True'}),
+            'itemID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'itemName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'regionID': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'security': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'solarSystemID': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['eve.Type']", 'db_column': "'typeID'"}),
+            'x': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'y': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'z': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'eve.controltowerresource': {
+            'Meta': {'ordering': "['control_tower', 'resource']", 'unique_together': "(('control_tower', 'resource'),)", 'object_name': 'ControlTowerResource'},
+            'control_tower': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tower_resources_t'", 'db_column': "'controlTowerTypeID'", 'to': "orm['eve.Type']"}),
+            'factionID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.BigIntegerField', [], {'primary_key': 'True'}),
+            'minSecurityLevel': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.SmallIntegerField', [], {}),
+            'quantity': ('django.db.models.fields.SmallIntegerField', [], {}),
+            'resource': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tower_resources_r'", 'db_column': "'resourceTypeID'", 'to': "orm['eve.Type']"})
+        },
+        'eve.group': {
+            'Meta': {'ordering': "['groupID']", 'object_name': 'Group'},
+            'allowManufacture': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'allowRecycler': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'anchorable': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'anchored': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'groups'", 'db_column': "'categoryID'", 'to': "orm['eve.Category']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'fittableNonSingleton': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'groupID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'groupName': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'useBasePrice': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'eve.marketgroup': {
+            'Meta': {'ordering': "['marketGroupID']", 'object_name': 'MarketGroup'},
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hasTypes': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'marketGroupID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'marketGroupName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'parent_group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children_groups'", 'null': 'True', 'db_column': "'parentGroupID'", 'to': "orm['eve.MarketGroup']"})
+        },
+        'eve.skillreq': {
+            'Meta': {'ordering': "['item', 'skill']", 'object_name': 'SkillReq'},
+            'id': ('django.db.models.fields.BigIntegerField', [], {'primary_key': 'True'}),
+            'item': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'skill_reqs'", 'to': "orm['eve.Type']"}),
+            'required_level': ('django.db.models.fields.SmallIntegerField', [], {}),
+            'skill': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['eve.Type']"})
+        },
+        'eve.type': {
+            'Meta': {'ordering': "['typeID']", 'object_name': 'Type'},
+            'basePrice': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'blueprint': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['eve.BlueprintType']", 'unique': 'True', 'null': 'True', 'db_column': "'blueprintTypeID'", 'blank': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'types'", 'db_column': "'categoryID'", 'to': "orm['eve.Category']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'types'", 'db_column': "'groupID'", 'to': "orm['eve.Group']"}),
+            'market_group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'items'", 'null': 'True', 'db_column': "'marketGroupID'", 'to': "orm['eve.MarketGroup']"}),
+            'metaGroupID': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'portionSize': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'raceID': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'typeID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'typeName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'volume': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['eve']

--- a/ecm/apps/eve/models.py
+++ b/ecm/apps/eve/models.py
@@ -156,6 +156,7 @@ class BlueprintType(models.Model):
     inventionTime = models.IntegerField(null=True, blank=True)
     maxProductionLimit = models.IntegerField(null=True, blank=True)
     inventionBaseChance = models.FloatField(null=True, blank=True)
+    product_is_purchased = models.BooleanField(default=False)
     __item = None
 
     def __getattr__(self, attr):
@@ -209,7 +210,8 @@ class BlueprintType(models.Model):
             mat_blueprint = mat.required_type.blueprint
             if mat_blueprint is not None:
                 blueprints.add(mat_blueprint)
-                if recurse:
+                #TODO: Stop recursing on things that are configured as product_is_purchased
+                if recurse and not mat_blueprint.product_is_purchased:
                     blueprints.update(mat_blueprint.get_involved_blueprints(recurse=True))
         return blueprints
 
@@ -364,7 +366,7 @@ class Type(models.Model):
         return self.typeName
 
     def __eq__(self, other):
-        return isinstance(other, Type) and other.typeID == self.typeID
+        return isinstance(other, Type) and other.typeID == self.type
 
     def __hash__(self):
         return self.typeID

--- a/ecm/plugins/industry/admin.py
+++ b/ecm/plugins/industry/admin.py
@@ -72,7 +72,7 @@ class SupplySourceAdmin(admin.ModelAdmin):
 #------------------------------------------------------------------------------
 class SupplyAdmin(admin.ModelAdmin):
     list_display = ['item_admin_display', 'price', 'auto_update', 'supply_source']
-    search_fields = ['item_admin_display']    
+    search_fields = ['type__typeName']    
 
 #------------------------------------------------------------------------------
 class PriceHistoryAdmin(admin.ModelAdmin):

--- a/ecm/plugins/industry/migrations/0005_auto__add_field_supply_type.py
+++ b/ecm/plugins/industry/migrations/0005_auto__add_field_supply_type.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        #XXX: HACK IT UP!  I want whatever OneToOneField gives me but I want it to turn off the uniqueness during creation until after
+        #migration is over.  Since the object doesn't listen to my creation of an explicit unique=False config then I'll hack to my
+        #hearts content for now...
+        field = self.gf('django.db.models.fields.related.OneToOneField')(default=1, to=orm['eve.Type'])
+        field._unique = False
+        # Adding field 'Supply.type'
+        db.add_column(u'industry_supply', 'type',
+                      field,
+                      keep_default=False)
+        if not db.dry_run:
+            supplies = orm['industry.supply'].objects.all()
+            for supply in supplies:
+                typeID = supply.typeID
+                typ = orm['eve.type'].objects.get(pk=typeID)
+                supply.type = typ
+                supply.save()
+            db.create_unique(u'industry_supply',['type_id'])
+
+
+    def backwards(self, orm):
+        # Deleting field 'Supply.type'
+        db.delete_column(u'industry_supply', 'type_id')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'eve.blueprinttype': {
+            'Meta': {'ordering': "['blueprintTypeID']", 'object_name': 'BlueprintType'},
+            'blueprintTypeID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'inventionBaseChance': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'inventionTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'maxProductionLimit': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parent_blueprint': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children_blueprints'", 'null': 'True', 'db_column': "'parentBlueprintTypeID'", 'to': "orm['eve.BlueprintType']"}),
+            'product': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['eve.Type']", 'unique': 'True', 'null': 'True', 'db_column': "'productTypeID'", 'blank': 'True'}),
+            'product_is_purchased': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'productionTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchCopyTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchMaterialTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'researchProductivityTime': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'eve.category': {
+            'Meta': {'ordering': "['categoryID']", 'object_name': 'Category'},
+            'categoryID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'categoryName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'eve.group': {
+            'Meta': {'ordering': "['groupID']", 'object_name': 'Group'},
+            'allowManufacture': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'allowRecycler': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'anchorable': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'anchored': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'groups'", 'db_column': "'categoryID'", 'to': "orm['eve.Category']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'fittableNonSingleton': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'groupID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'groupName': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'useBasePrice': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'eve.marketgroup': {
+            'Meta': {'ordering': "['marketGroupID']", 'object_name': 'MarketGroup'},
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hasTypes': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'iconID': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'marketGroupID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'marketGroupName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'parent_group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children_groups'", 'null': 'True', 'db_column': "'parentGroupID'", 'to': "orm['eve.MarketGroup']"})
+        },
+        'eve.type': {
+            'Meta': {'ordering': "['typeID']", 'object_name': 'Type'},
+            'basePrice': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'blueprint': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['eve.BlueprintType']", 'unique': 'True', 'null': 'True', 'db_column': "'blueprintTypeID'", 'blank': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'types'", 'db_column': "'categoryID'", 'to': "orm['eve.Category']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'types'", 'db_column': "'groupID'", 'to': "orm['eve.Group']"}),
+            'market_group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'items'", 'null': 'True', 'db_column': "'marketGroupID'", 'to': "orm['eve.MarketGroup']"}),
+            'metaGroupID': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'portionSize': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.SmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'raceID': ('django.db.models.fields.SmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'typeID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'typeName': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'volume': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'industry.catalogentry': {
+            'Meta': {'object_name': 'CatalogEntry'},
+            'fixed_price': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'is_available': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'last_update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'production_cost': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'public_price': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'typeID': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'typeName': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'industry.inventionpolicy': {
+            'Meta': {'object_name': 'InventionPolicy'},
+            'encryption_skill_lvl': ('django.db.models.fields.SmallIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_group': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'item_group_id': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'item_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'me_mod': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'science1_skill_lvl': ('django.db.models.fields.SmallIntegerField', [], {'default': '5'}),
+            'science2_skill_lvl': ('django.db.models.fields.SmallIntegerField', [], {'default': '5'})
+        },
+        'industry.itemgroup': {
+            'Meta': {'object_name': 'ItemGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'items': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'item_groups'", 'symmetrical': 'False', 'to': "orm['industry.CatalogEntry']"}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'industry.job': {
+            'Meta': {'object_name': 'Job'},
+            'activity': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'assignee': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'blueprint': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['industry.OwnedBlueprint']"}),
+            'due_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'duration': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs'", 'null': 'True', 'to': "orm['industry.Order']"}),
+            'parent_job': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children_jobs'", 'null': 'True', 'to': "orm['industry.Job']"}),
+            'row': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs'", 'null': 'True', 'to': "orm['industry.OrderRow']"}),
+            'runs': ('django.db.models.fields.FloatField', [], {}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'})
+        },
+        'industry.order': {
+            'Meta': {'object_name': 'Order'},
+            'client': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'delivery_boy': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'orders_delivered'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'delivery_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'delivery_location': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'originator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'orders_created'", 'to': u"orm['auth.User']"}),
+            'quote': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'responsible': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'orders_responsible'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'state': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'industry.orderlog': {
+            'Meta': {'ordering': "['order', 'date']", 'object_name': 'OrderLog'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'logs'", 'to': "orm['industry.Order']"}),
+            'state': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'logs'", 'to': u"orm['auth.User']"})
+        },
+        'industry.orderrow': {
+            'Meta': {'ordering': "['order']", 'object_name': 'OrderRow'},
+            'catalog_entry': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'order_rows'", 'to': "orm['industry.CatalogEntry']"}),
+            'cost': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'rows'", 'to': "orm['industry.Order']"}),
+            'quantity': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'surcharge': ('django.db.models.fields.FloatField', [], {'default': '0.0'})
+        },
+        'industry.ownedblueprint': {
+            'Meta': {'object_name': 'OwnedBlueprint'},
+            'catalog_entry': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'blueprints'", 'null': 'True', 'to': "orm['industry.CatalogEntry']"}),
+            'copy': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invented': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'me': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'pe': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'runs': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'typeID': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'industry.pricehistory': {
+            'Meta': {'object_name': 'PriceHistory'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'price': ('django.db.models.fields.FloatField', [], {}),
+            'supply': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'price_histories'", 'to': "orm['industry.Supply']"})
+        },
+        'industry.pricingpolicy': {
+            'Meta': {'object_name': 'PricingPolicy'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'item_group': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['industry.ItemGroup']", 'null': 'True', 'blank': 'True'}),
+            'priority': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'surcharge_absolute': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'surcharge_relative': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'user_group': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'})
+        },
+        'industry.supply': {
+            'Meta': {'object_name': 'Supply'},
+            'auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'price': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'supply_source': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'related_name': "'prices'", 'to': "orm['industry.SupplySource']"}),
+            'type': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['eve.Type']", 'unique': 'True'}),
+            'typeID': ('django.db.models.fields.PositiveIntegerField', [], {'primary_key': 'True'})
+        },
+        'industry.supplysource': {
+            'Meta': {'object_name': 'SupplySource'},
+            'location_id': ('django.db.models.fields.PositiveIntegerField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['industry']

--- a/ecm/plugins/industry/models/catalog.py
+++ b/ecm/plugins/industry/models/catalog.py
@@ -60,7 +60,7 @@ class CatalogEntry(models.Model):
     def missing_blueprints(self, skip_invented=True):
         involved_bps = set()
         for bp in self.blueprint.get_involved_blueprints(recurse=True) | set([self.blueprint]):
-            if skip_invented and bp.product.metaGroupID == 2 and bp.parentBlueprintTypeID is not None:
+            if skip_invented and bp.product.metaGroupID == 2 and bp.parentBlueprintTypeID is not None or bp.product_is_purchased:
                 continue
             else:
                 involved_bps.add(bp)

--- a/ecm/plugins/industry/models/inventory.py
+++ b/ecm/plugins/industry/models/inventory.py
@@ -47,6 +47,10 @@ class Supply(models.Model):
     price = models.FloatField(default=0.0)
     auto_update = models.BooleanField(default=True)
     supply_source = models.ForeignKey('SupplySource', related_name='prices', default=1)
+    #TODO: Refactor the above typeID or learn django/south better so that this reference
+    #is loaded during the migration
+    type = models.OneToOneField(Type);
+    
     __item = None
 
     def update_price(self, newPrice):

--- a/ecm/plugins/industry/views/__init__.py
+++ b/ecm/plugins/industry/views/__init__.py
@@ -73,7 +73,7 @@ def create_missing_supplies():
     missing_ids = eve_typeIDs - ecm_typeIDs
 
     for typeID in missing_ids:
-        Supply.objects.create(typeID=typeID)
+        Supply.objects.create(typeID=typeID, type = Type.objects.get(pk=typeID))
 
     if missing_ids:
         duration = time.time() - start


### PR DESCRIPTION
No tests as I'm not fully up to speed on the testing process in django just yet, thats a task for another day.

The tweak I put in for configured bought components seems to have been much easier than what I planned.  The outcome was that those became supply runs (which was a nice offshoot and awesome that I didn't have to code it).

The other... I dove down that rabbit hole for some reason... not entirely sure why and when the feature didn't work I felt like learning something or practicing something and fixing it :D.
