### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ for scheme in INSTALL_SCHEMES.values():
     scheme['data'] = scheme['purelib']
 
 dependencies = [
-    'django_simple_captcha >= 0.3',
+    'django_simple_captcha < 0.4.0',
     'south >= 0.8',
-    'django_compressor >= 1.1.2',
+    'django_compressor < 2.0.0',
     'setuptools',
     'django <= 1.5.7',
     'pytz',


### PR DESCRIPTION
Limit django_simple_captcha to < 0.4 to fix https://github.com/evecm/ecm/issues/42 (as per bllevy2).
Limit django_compressor to < 2.0.0, as this latest version breaks compressor.